### PR TITLE
feat: Implement Piano Roll UI components

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,20 +26,25 @@ Application state, primarily lists of notes and events, is managed using React C
 
 The application now features a more integrated and visually detailed interactive music editing interface:
 
-*   **Vertical Piano Keyboard**: A `src/components/PianoKeyboard.tsx` component displays the full MIDI note range (0-127) in a vertical orientation, with the highest note at the top. Keys are labeled (e.g., C4, F#5), C4 is highlighted, and importantly, each key's height is synchronized with the note lanes in the Piano Roll, providing a direct visual guide for pitch.
-*   **Enhanced Piano Roll**: The `src/components/PianoRoll.tsx` uses a canvas to render its grid. This grid now features a subtle background color for lanes corresponding to black piano keys, improving visual distinction. It displays notes sourced from `MusicDataContext`.
-*   **Note Display & Interaction**: Individual musical notes (`src/components/Note.tsx`) are rendered on the piano roll. These notes support:
-    *   **Selection**: Clicking a note selects it (visual feedback provided).
-    *   **Deletion**: Pressing 'Delete' or 'Backspace' on a selected note removes it.
-    *   **Lyric Editing**: Pressing 'Enter' on a selected note enables direct lyric editing.
-*   **Integrated Layout**: The Piano Keyboard and Piano Roll are displayed in a gapless, side-by-side layout within `src/App.tsx`, ensuring their top edges are aligned for a cohesive user experience.
+*   **Vertical Piano Keyboard**: The `src/components/PianoKeyboard.tsx` component displays a vertical piano keyboard (MIDI 0-127, highest note at the top).
+    *   Keys are labeled (e.g., C4, F#5), and C4 is highlighted.
+    *   Each key's height is synchronized with `PianoRoll` note lanes for direct pitch alignment.
+    *   White keys feature a bottom border for better visual separation.
+    *   Black keys now have the same depth (interaction width) as white keys, while remaining visually distinct.
+*   **Enhanced Piano Roll**: The `src/components/PianoRoll.tsx` uses a canvas to render its grid.
+    *   This grid features a subtle background color for lanes corresponding to black piano keys, improving visual distinction.
+    *   It displays notes sourced from `MusicDataContext`.
+*   **Note Display & Interaction**: Individual musical notes (`src/components/Note.tsx`) are rendered on the piano roll and support selection, deletion, and lyric editing.
+*   **Integrated Layout & Scrolling**:
+    *   The Piano Keyboard and Piano Roll are displayed in a gapless, side-by-side layout (`src/App.tsx`), aligned at their top edges.
+    *   Vertical scrolling of the Piano Keyboard and Piano Roll areas is synchronized, ensuring a consistent view when navigating through pitches.
 *   **Control Area**: A section (`src/components/ControlArea.tsx`) remains for managing musical events like tempo and time signature changes.
 
 ## Key Components
 
-*   **`src/App.tsx`**: The main application component that sets up the overall layout, including the tightly integrated side-by-side Piano Keyboard (vertical) and Piano Roll, along with necessary data providers.
-*   **`src/components/PianoRoll.tsx`**: Renders an HTML5 Canvas-based grid representing pitch and time. Note lanes for black keys have a distinct background color. It displays `NoteComponent` instances based on data from `MusicDataContext` and manages note selection.
-*   **`src/components/PianoKeyboard.tsx`**: Displays a vertical visual piano keyboard covering all 128 MIDI notes. Key heights are synchronized with `PianoRoll` note lanes. It includes note labels and a highlighted C4, positioned to the left of the Piano Roll.
+*   **`src/App.tsx`**: The main application component. It sets up the overall layout, including the tightly integrated side-by-side Piano Keyboard and Piano Roll, and implements their scroll synchronization. It also provides necessary data contexts.
+*   **`src/components/PianoRoll.tsx`**: Renders an HTML5 Canvas-based grid representing pitch and time. Note lanes for black keys have a distinct background color. It displays `NoteComponent` instances based on data from `MusicDataContext` and manages note selection. Its internal padding and title have been removed for a cleaner integration.
+*   **`src/components/PianoKeyboard.tsx`**: Displays a vertical visual piano keyboard covering all 128 MIDI notes. Key heights are synchronized with `PianoRoll` note lanes. White keys have bottom borders, and black keys share the same depth as white keys. It includes note labels and a highlighted C4. Its internal padding and title have been removed.
 *   **`src/components/Note.tsx`**: Represents an individual musical note as an absolutely positioned HTML element over the Piano Roll. It handles its own display (lyric, selection state) and user interactions (selection, deletion, lyric editing via callbacks).
 *   **`src/components/ControlArea.tsx`**: A component for displaying and interacting with control events like tempo and time signature changes.
 

--- a/README.md
+++ b/README.md
@@ -22,11 +22,25 @@ Application state, primarily lists of notes and events, is managed using React C
 *   Notes and events are stored in `Map` objects, keyed by their unique IDs.
 *   Context provides functions for CRUD operations (Create, Read, Update, Delete) on notes and events (e.g., `addNote`, `deleteEvent`).
 
+## UI Features
+
+The application now features a basic interactive music editing interface:
+
+*   **Piano Keyboard**: A visual representation of a piano keyboard (`src/components/PianoKeyboard.tsx`) displaying the full MIDI note range (0-127). Keys are labeled with note names (e.g., C4, F#5), and C4 is highlighted as a reference.
+*   **Piano Roll**: A canvas-based piano roll (`src/components/PianoRoll.tsx`) that visually represents musical notes against a grid of pitches and time. It displays notes sourced from the `MusicDataContext`.
+*   **Note Display**: Individual musical notes (`src/components/Note.tsx`) are rendered on the piano roll. These notes are interactive:
+    *   **Selection**: Clicking a note selects it, visually highlighting it.
+    *   **Deletion**: Pressing 'Delete' or 'Backspace' when a note is selected removes it.
+    *   **Lyric Editing**: Pressing 'Enter' on a selected note allows editing its lyric directly on the note.
+*   **Control Area**: A section (`src/components/ControlArea.tsx`) for managing musical events like tempo and time signature changes.
+
 ## Key Components
 
-*   **`src/App.tsx`**: The main application component that sets up the overall layout and providers.
-*   **`src/components/PianoRoll.tsx`**: A placeholder component for displaying and interacting with musical notes. Currently shows a list of notes and allows adding sample notes and deleting existing ones.
-*   **`src/components/ControlArea.tsx`**: A placeholder component for displaying and interacting with control events like tempo and time signature changes. Currently shows a list of events and allows adding sample events and deleting existing ones.
+*   **`src/App.tsx`**: The main application component that sets up the overall layout (including the side-by-side Piano Keyboard and Piano Roll) and providers.
+*   **`src/components/PianoRoll.tsx`**: Renders a canvas-based grid for pitch and time. It displays `NoteComponent` instances based on data from `MusicDataContext` and manages note selection.
+*   **`src/components/PianoKeyboard.tsx`**: Displays a visual piano keyboard with all 128 MIDI notes, labels, and a highlighted C4. It's positioned to the left of the Piano Roll.
+*   **`src/components/Note.tsx`**: Represents an individual musical note as an absolutely positioned HTML element over the Piano Roll. It handles its own display (lyric, selection state) and user interactions (selection, deletion, lyric editing via callbacks).
+*   **`src/components/ControlArea.tsx`**: A component for displaying and interacting with control events like tempo and time signature changes.
 
 ## Recommended IDE Setup
 
@@ -70,31 +84,30 @@ This will compile the Rust backend in release mode and build the frontend assets
 
 ## Testing
 
-Currently, testing is primarily done through manual interaction with the UI:
-1.  Run `pnpm tauri dev`.
-2.  Use the "Add Sample Note/Event" buttons to populate data.
-3.  Verify that notes and events are displayed correctly.
-4.  Use the "Delete Note/Event" buttons and verify items are removed.
+Unit tests for key React components have been implemented using [React Testing Library](https://testing-library.com/docs/react-testing-library/intro/) and [Jest](https://jestjs.io/) (via Vitest's Jest-compatible API if using Vitest, or directly if Jest is configured).
 
-Formal automated tests (e.g., using Vitest) are not yet implemented for the data manipulation logic or components but can be added. If Vitest is set up (as suggested by the original template), you could run tests using:
+*   **Test Files**: Located alongside the components they test (e.g., `src/components/PianoRoll.test.tsx`).
+*   **Covered Components**: `PianoKeyboard`, `PianoRoll`, and `NoteComponent` (from `Note.tsx`) have unit tests covering rendering, basic interactions, and callback invocations.
+*   **Mocks**: `useMusicData` context and child components (like `NoteComponent` within `PianoRoll` tests) are mocked where appropriate to isolate component logic.
+
+**Running Tests:**
+
+To run the unit tests, use the following command in the project root directory:
 
 ```bash
 pnpm test
 ```
+This command will execute the test suite and report results. (Ensure Vitest or your chosen test runner is configured in `package.json`'s `scripts` section for this command).
 
-You would need to create test files (e.g., `*.test.ts` or `*.spec.ts`) with actual test cases. For example, to test context functions:
-```typescript
-// Example: src/contexts/MusicDataContext.test.ts
-import { describe, it, expect } from 'vitest';
-// ... import functions from context or a test wrapper
+**Manual Testing:**
 
-describe('MusicDataContext', () => {
-  it('should add a note correctly', () => {
-    // Test logic here
-    // const { result } = renderHook(() => useMusicData(), { wrapper: MusicDataProvider });
-    // act(() => { result.current.addNote(...); });
-    // expect(result.current.notes.size).toBe(1);
-  });
-});
-```
-(The above test snippet is a conceptual example and would require further setup like `@testing-library/react-hooks` or similar for testing hooks.)
+Manual interaction with the UI is still valuable for end-to-end testing:
+
+1.  Run `pnpm tauri dev`.
+2.  Use the "Add Sample Note/Event" buttons in the "Control Area" to populate data if needed (or implement other ways to add notes).
+3.  **Interact with Notes**:
+    *   Click on notes in the Piano Roll to select/deselect them.
+    *   With a note selected, press 'Delete' or 'Backspace' to remove it.
+    *   With a note selected, press 'Enter' to edit its lyric. Type a new lyric and press 'Enter' to confirm or 'Escape' to cancel.
+4.  Verify that the Piano Keyboard correctly displays note positions and highlights C4.
+5.  Verify that events (Tempo, Time Signature) are displayed and can be manipulated in the "Control Area".

--- a/README.md
+++ b/README.md
@@ -24,21 +24,22 @@ Application state, primarily lists of notes and events, is managed using React C
 
 ## UI Features
 
-The application now features a basic interactive music editing interface:
+The application now features a more integrated and visually detailed interactive music editing interface:
 
-*   **Piano Keyboard**: A visual representation of a piano keyboard (`src/components/PianoKeyboard.tsx`) displaying the full MIDI note range (0-127). Keys are labeled with note names (e.g., C4, F#5), and C4 is highlighted as a reference.
-*   **Piano Roll**: A canvas-based piano roll (`src/components/PianoRoll.tsx`) that visually represents musical notes against a grid of pitches and time. It displays notes sourced from the `MusicDataContext`.
-*   **Note Display**: Individual musical notes (`src/components/Note.tsx`) are rendered on the piano roll. These notes are interactive:
-    *   **Selection**: Clicking a note selects it, visually highlighting it.
-    *   **Deletion**: Pressing 'Delete' or 'Backspace' when a note is selected removes it.
-    *   **Lyric Editing**: Pressing 'Enter' on a selected note allows editing its lyric directly on the note.
-*   **Control Area**: A section (`src/components/ControlArea.tsx`) for managing musical events like tempo and time signature changes.
+*   **Vertical Piano Keyboard**: A `src/components/PianoKeyboard.tsx` component displays the full MIDI note range (0-127) in a vertical orientation, with the highest note at the top. Keys are labeled (e.g., C4, F#5), C4 is highlighted, and importantly, each key's height is synchronized with the note lanes in the Piano Roll, providing a direct visual guide for pitch.
+*   **Enhanced Piano Roll**: The `src/components/PianoRoll.tsx` uses a canvas to render its grid. This grid now features a subtle background color for lanes corresponding to black piano keys, improving visual distinction. It displays notes sourced from `MusicDataContext`.
+*   **Note Display & Interaction**: Individual musical notes (`src/components/Note.tsx`) are rendered on the piano roll. These notes support:
+    *   **Selection**: Clicking a note selects it (visual feedback provided).
+    *   **Deletion**: Pressing 'Delete' or 'Backspace' on a selected note removes it.
+    *   **Lyric Editing**: Pressing 'Enter' on a selected note enables direct lyric editing.
+*   **Integrated Layout**: The Piano Keyboard and Piano Roll are displayed in a gapless, side-by-side layout within `src/App.tsx`, ensuring their top edges are aligned for a cohesive user experience.
+*   **Control Area**: A section (`src/components/ControlArea.tsx`) remains for managing musical events like tempo and time signature changes.
 
 ## Key Components
 
-*   **`src/App.tsx`**: The main application component that sets up the overall layout (including the side-by-side Piano Keyboard and Piano Roll) and providers.
-*   **`src/components/PianoRoll.tsx`**: Renders a canvas-based grid for pitch and time. It displays `NoteComponent` instances based on data from `MusicDataContext` and manages note selection.
-*   **`src/components/PianoKeyboard.tsx`**: Displays a visual piano keyboard with all 128 MIDI notes, labels, and a highlighted C4. It's positioned to the left of the Piano Roll.
+*   **`src/App.tsx`**: The main application component that sets up the overall layout, including the tightly integrated side-by-side Piano Keyboard (vertical) and Piano Roll, along with necessary data providers.
+*   **`src/components/PianoRoll.tsx`**: Renders an HTML5 Canvas-based grid representing pitch and time. Note lanes for black keys have a distinct background color. It displays `NoteComponent` instances based on data from `MusicDataContext` and manages note selection.
+*   **`src/components/PianoKeyboard.tsx`**: Displays a vertical visual piano keyboard covering all 128 MIDI notes. Key heights are synchronized with `PianoRoll` note lanes. It includes note labels and a highlighted C4, positioned to the left of the Piano Roll.
 *   **`src/components/Note.tsx`**: Represents an individual musical note as an absolutely positioned HTML element over the Piano Roll. It handles its own display (lyric, selection state) and user interactions (selection, deletion, lyric editing via callbacks).
 *   **`src/components/ControlArea.tsx`**: A component for displaying and interacting with control events like tempo and time signature changes.
 

--- a/package.json
+++ b/package.json
@@ -18,7 +18,9 @@
   },
   "devDependencies": {
     "@tauri-apps/cli": "^2",
+    "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/react": "^16.3.0",
+    "@testing-library/user-event": "^14.6.1",
     "@types/react": "^18.3.1",
     "@types/react-dom": "^18.3.1",
     "@types/uuid": "^10.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,15 +24,24 @@ importers:
       '@tauri-apps/cli':
         specifier: ^2
         version: 2.5.0
+      '@testing-library/jest-dom':
+        specifier: ^6.6.3
+        version: 6.6.3
       '@testing-library/react':
         specifier: ^16.3.0
         version: 16.3.0(@testing-library/dom@10.4.0)(@types/react-dom@18.3.7(@types/react@18.3.23))(@types/react@18.3.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@testing-library/user-event':
+        specifier: ^14.6.1
+        version: 14.6.1(@testing-library/dom@10.4.0)
       '@types/react':
         specifier: ^18.3.1
         version: 18.3.23
       '@types/react-dom':
         specifier: ^18.3.1
         version: 18.3.7(@types/react@18.3.23)
+      '@types/uuid':
+        specifier: ^10.0.0
+        version: 10.0.0
       '@vitejs/plugin-react':
         specifier: ^4.3.4
         version: 4.5.0(vite@6.3.5)
@@ -42,6 +51,9 @@ importers:
       typescript:
         specifier: ~5.6.2
         version: 5.6.3
+      uuid:
+        specifier: ^11.1.0
+        version: 11.1.0
       vite:
         specifier: ^6.0.3
         version: 6.3.5
@@ -50,6 +62,9 @@ importers:
         version: 3.1.4(happy-dom@17.5.6)
 
 packages:
+
+  '@adobe/css-tools@4.4.3':
+    resolution: {integrity: sha512-VQKMkwriZbaOgVCby1UDY/LDk5fIjhQicCvVPFqfe+69fWaPWydbWJ3wRt59/YzIwda1I81loas3oCoHxnqvdA==}
 
   '@ampproject/remapping@2.3.0':
     resolution: {integrity: sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==}
@@ -490,6 +505,10 @@ packages:
     resolution: {integrity: sha512-pemlzrSESWbdAloYml3bAJMEfNh1Z7EduzqPKprCH5S341frlpYnUEW0H72dLxa6IsYr+mPno20GiSm+h9dEdQ==}
     engines: {node: '>=18'}
 
+  '@testing-library/jest-dom@6.6.3':
+    resolution: {integrity: sha512-IteBhl4XqYNkM54f4ejhLRJiZNqcSCoXUOG2CPK7qbD322KjQozM4kHQOfkG2oln9b9HTYqs+Sae8vBATubxxA==}
+    engines: {node: '>=14', npm: '>=6', yarn: '>=1'}
+
   '@testing-library/react@16.3.0':
     resolution: {integrity: sha512-kFSyxiEDwv1WLl2fgsq6pPBbw5aWKrsY2/noi1Id0TK0UParSF62oFQFGHXIyaG4pp2tEub/Zlel+fjjZILDsw==}
     engines: {node: '>=18'}
@@ -504,6 +523,12 @@ packages:
         optional: true
       '@types/react-dom':
         optional: true
+
+  '@testing-library/user-event@14.6.1':
+    resolution: {integrity: sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==}
+    engines: {node: '>=12', npm: '>=6'}
+    peerDependencies:
+      '@testing-library/dom': '>=7.21.4'
 
   '@types/aria-query@5.0.4':
     resolution: {integrity: sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==}
@@ -533,6 +558,9 @@ packages:
 
   '@types/react@18.3.23':
     resolution: {integrity: sha512-/LDXMQh55EzZQ0uVAZmKKhfENivEvWz6E+EYzh+/MCjMhNsotd+ZHhBGIjFDTi6+fz0OhQQQLbTgdQIxxCsC0w==}
+
+  '@types/uuid@10.0.0':
+    resolution: {integrity: sha512-7gqG38EyHgyP1S+7+xomFtL+ZNHcKv6DwNaCZmJmo1vgMugyF3TCnXVg4t1uk89mLNwnLtnY3TpOpCOyp1/xHQ==}
 
   '@vitejs/plugin-react@4.5.0':
     resolution: {integrity: sha512-JuLWaEqypaJmOJPLWwO335Ig6jSgC1FTONCWAxnqcQthLTK/Yc9aH6hr9z/87xciejbQcnP3GnA1FWUSWeXaeg==}
@@ -604,6 +632,10 @@ packages:
     resolution: {integrity: sha512-mCuXncKXk5iCLhfhwTc0izo0gtEmpz5CtG2y8GiOINBlMVS6v8TMRc5TaLWKS6692m9+dVVfzgeVxR5UxWHTYw==}
     engines: {node: '>=12'}
 
+  chalk@3.0.0:
+    resolution: {integrity: sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==}
+    engines: {node: '>=8'}
+
   chalk@4.1.2:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
     engines: {node: '>=10'}
@@ -621,6 +653,9 @@ packages:
 
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
+
+  css.escape@1.5.1:
+    resolution: {integrity: sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==}
 
   csstype@3.1.3:
     resolution: {integrity: sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==}
@@ -644,6 +679,9 @@ packages:
 
   dom-accessibility-api@0.5.16:
     resolution: {integrity: sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==}
+
+  dom-accessibility-api@0.6.3:
+    resolution: {integrity: sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==}
 
   electron-to-chromium@1.5.161:
     resolution: {integrity: sha512-hwtetwfKNZo/UlwHIVBlKZVdy7o8bIZxxKs0Mv/ROPiQQQmDgdm5a+KvKtBsxM8ZjFzTaCeLoodZ8jiBE3o9rA==}
@@ -696,6 +734,10 @@ packages:
     resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
     engines: {node: '>=8'}
 
+  indent-string@4.0.0:
+    resolution: {integrity: sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==}
+    engines: {node: '>=8'}
+
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
@@ -708,6 +750,9 @@ packages:
     resolution: {integrity: sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==}
     engines: {node: '>=6'}
     hasBin: true
+
+  lodash@4.17.21:
+    resolution: {integrity: sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==}
 
   loose-envify@1.4.0:
     resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
@@ -725,6 +770,10 @@ packages:
 
   magic-string@0.30.17:
     resolution: {integrity: sha512-sNPKHvyjVf7gyjwS4xGTaW/mCnF8wnjtifKBEhxfZ7E/S8tQ0rssrwGNn6q8JH/ohItJfSQp9mBtQYuTlH5QnA==}
+
+  min-indent@1.0.1:
+    resolution: {integrity: sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==}
+    engines: {node: '>=4'}
 
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
@@ -775,6 +824,10 @@ packages:
     resolution: {integrity: sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==}
     engines: {node: '>=0.10.0'}
 
+  redent@3.0.0:
+    resolution: {integrity: sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==}
+    engines: {node: '>=8'}
+
   rollup@4.41.1:
     resolution: {integrity: sha512-cPmwD3FnFv8rKMBc1MxWCwVQFxwf1JEmSX3iQXrRVVG15zerAIXRjMFVWnd5Q5QvgKF7Aj+5ykXFhUl+QGnyOw==}
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
@@ -799,6 +852,10 @@ packages:
 
   std-env@3.9.0:
     resolution: {integrity: sha512-UGvjygr6F6tpH7o2qyqR6QYpwraIjKSdtzyBdyytFOHmPZY917kwdwLG0RbOjWOnKmnm3PeHjaoLLMie7kPLQw==}
+
+  strip-indent@3.0.0:
+    resolution: {integrity: sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==}
+    engines: {node: '>=8'}
 
   supports-color@7.2.0:
     resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
@@ -836,6 +893,10 @@ packages:
     hasBin: true
     peerDependencies:
       browserslist: '>= 4.21.0'
+
+  uuid@11.1.0:
+    resolution: {integrity: sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==}
+    hasBin: true
 
   vite-node@3.1.4:
     resolution: {integrity: sha512-6enNwYnpyDo4hEgytbmc6mYWHXDHYEn0D1/rw4Q+tnHUGtKTJsn8T1YkX6Q18wI5LCrS8CTYlBaiCqxOy2kvUA==}
@@ -927,6 +988,8 @@ packages:
     resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
 
 snapshots:
+
+  '@adobe/css-tools@4.4.3': {}
 
   '@ampproject/remapping@2.3.0':
     dependencies:
@@ -1263,6 +1326,16 @@ snapshots:
       lz-string: 1.5.0
       pretty-format: 27.5.1
 
+  '@testing-library/jest-dom@6.6.3':
+    dependencies:
+      '@adobe/css-tools': 4.4.3
+      aria-query: 5.3.0
+      chalk: 3.0.0
+      css.escape: 1.5.1
+      dom-accessibility-api: 0.6.3
+      lodash: 4.17.21
+      redent: 3.0.0
+
   '@testing-library/react@16.3.0(@testing-library/dom@10.4.0)(@types/react-dom@18.3.7(@types/react@18.3.23))(@types/react@18.3.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@babel/runtime': 7.27.4
@@ -1272,6 +1345,10 @@ snapshots:
     optionalDependencies:
       '@types/react': 18.3.23
       '@types/react-dom': 18.3.7(@types/react@18.3.23)
+
+  '@testing-library/user-event@14.6.1(@testing-library/dom@10.4.0)':
+    dependencies:
+      '@testing-library/dom': 10.4.0
 
   '@types/aria-query@5.0.4': {}
 
@@ -1308,6 +1385,8 @@ snapshots:
     dependencies:
       '@types/prop-types': 15.7.14
       csstype: 3.1.3
+
+  '@types/uuid@10.0.0': {}
 
   '@vitejs/plugin-react@4.5.0(vite@6.3.5)':
     dependencies:
@@ -1394,6 +1473,11 @@ snapshots:
       loupe: 3.1.3
       pathval: 2.0.0
 
+  chalk@3.0.0:
+    dependencies:
+      ansi-styles: 4.3.0
+      supports-color: 7.2.0
+
   chalk@4.1.2:
     dependencies:
       ansi-styles: 4.3.0
@@ -1409,6 +1493,8 @@ snapshots:
 
   convert-source-map@2.0.0: {}
 
+  css.escape@1.5.1: {}
+
   csstype@3.1.3: {}
 
   debug@4.4.1:
@@ -1420,6 +1506,8 @@ snapshots:
   dequal@2.0.3: {}
 
   dom-accessibility-api@0.5.16: {}
+
+  dom-accessibility-api@0.6.3: {}
 
   electron-to-chromium@1.5.161: {}
 
@@ -1479,11 +1567,15 @@ snapshots:
 
   has-flag@4.0.0: {}
 
+  indent-string@4.0.0: {}
+
   js-tokens@4.0.0: {}
 
   jsesc@3.1.0: {}
 
   json5@2.2.3: {}
+
+  lodash@4.17.21: {}
 
   loose-envify@1.4.0:
     dependencies:
@@ -1500,6 +1592,8 @@ snapshots:
   magic-string@0.30.17:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.0
+
+  min-indent@1.0.1: {}
 
   ms@2.1.3: {}
 
@@ -1541,6 +1635,11 @@ snapshots:
     dependencies:
       loose-envify: 1.4.0
 
+  redent@3.0.0:
+    dependencies:
+      indent-string: 4.0.0
+      strip-indent: 3.0.0
+
   rollup@4.41.1:
     dependencies:
       '@types/estree': 1.0.7
@@ -1581,6 +1680,10 @@ snapshots:
 
   std-env@3.9.0: {}
 
+  strip-indent@3.0.0:
+    dependencies:
+      min-indent: 1.0.1
+
   supports-color@7.2.0:
     dependencies:
       has-flag: 4.0.0
@@ -1607,6 +1710,8 @@ snapshots:
       browserslist: 4.25.0
       escalade: 3.2.0
       picocolors: 1.1.1
+
+  uuid@11.1.0: {}
 
   vite-node@3.1.4:
     dependencies:

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,13 +8,13 @@ import { ControlArea } from './components/ControlArea';
 function App() {
   return (
     <MusicDataProvider>
-      <div className="app-container" style={{ padding: '20px', display: 'flex', flexDirection: 'column', height: '100vh' }}>
-        <h1 style={{ textAlign: 'center', marginBottom: '20px' }}>Music Editor Prototype</h1>
-        <div className="main-content" style={{ display: 'flex', flexGrow: 1, overflow: 'hidden' }}>
-          <div className="keyboard-area" style={{ marginRight: '10px', overflowY: 'auto', flexShrink: 0 }}>
+      <div className="app-container" style={{ padding: '20px', display: 'flex', flexDirection: 'column', height: 'calc(100vh - 40px)' /* Adjust for padding */ }}>
+        <h1 style={{ textAlign: 'center', marginBottom: '20px', flexShrink: 0 }}>Music Editor Prototype</h1>
+        <div className="main-content" style={{ display: 'flex', flexGrow: 1, overflow: 'hidden', alignItems: 'flex-start' /* Align items to the top */ }}>
+          <div className="keyboard-area" style={{ overflowY: 'auto', flexShrink: 0, height: '100%' /* Allow keyboard to scroll if taller than main-content */ }}>
             <PianoKeyboard />
           </div>
-          <div className="pianoroll-area" style={{ flexGrow: 1, overflow: 'auto' }}>
+          <div className="pianoroll-area" style={{ flexGrow: 1, overflow: 'auto', height: '100%' /* Allow piano roll to scroll if taller */ }}>
             <PianoRoll />
           </div>
         </div>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,20 +1,28 @@
 // src/App.tsx
 import { MusicDataProvider } from './contexts/MusicDataContext';
 import { PianoRoll } from './components/PianoRoll';
+import { PianoKeyboard } from './components/PianoKeyboard';
 import { ControlArea } from './components/ControlArea';
-// If there's a default App.css or index.css, ensure it's imported or styles are handled.
 // import './App.css'; // Or your main CSS file
 
 function App() {
   return (
     <MusicDataProvider>
-      <div className="container" style={{ padding: '20px' }}>
-        <h1>Music Editor Prototype</h1>
-        <PianoRoll />
-        <ControlArea />
+      <div className="app-container" style={{ padding: '20px', display: 'flex', flexDirection: 'column', height: '100vh' }}>
+        <h1 style={{ textAlign: 'center', marginBottom: '20px' }}>Music Editor Prototype</h1>
+        <div className="main-content" style={{ display: 'flex', flexGrow: 1, overflow: 'hidden' }}>
+          <div className="keyboard-area" style={{ marginRight: '10px', overflowY: 'auto', flexShrink: 0 }}>
+            <PianoKeyboard />
+          </div>
+          <div className="pianoroll-area" style={{ flexGrow: 1, overflow: 'auto' }}>
+            <PianoRoll />
+          </div>
+        </div>
+        <div className="control-area-container" style={{ marginTop: '20px', flexShrink: 0 }}>
+          <ControlArea />
+        </div>
         {/*
           More complex forms for adding notes/events can be added here or within the components themselves.
-          For now, sample add buttons are within PianoRoll and ControlArea.
         */}
       </div>
     </MusicDataProvider>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,5 @@
 // src/App.tsx
+import { useRef, useEffect } from 'react'; // Removed unused React default import
 import { MusicDataProvider } from './contexts/MusicDataContext';
 import { PianoRoll } from './components/PianoRoll';
 import { PianoKeyboard } from './components/PianoKeyboard';
@@ -6,15 +7,67 @@ import { ControlArea } from './components/ControlArea';
 // import './App.css'; // Or your main CSS file
 
 function App() {
+  const keyboardScrollRef = useRef<HTMLDivElement>(null);
+  const pianoRollScrollRef = useRef<HTMLDivElement>(null);
+  const isSyncingScroll = useRef(false);
+  // Using a slightly more robust RAF-based approach for resetting the sync flag
+  const syncRafRef = useRef<number | null>(null);
+
+
+  useEffect(() => {
+    const keyboardEl = keyboardScrollRef.current;
+    const pianoRollEl = pianoRollScrollRef.current;
+
+    if (!keyboardEl || !pianoRollEl) return;
+
+    const handleKeyboardScroll = () => {
+      if (syncRafRef.current) cancelAnimationFrame(syncRafRef.current);
+      if (isSyncingScroll.current) {
+        isSyncingScroll.current = false; // Reset if we are the source of the immediate previous sync
+        return;
+      }
+      isSyncingScroll.current = true;
+      pianoRollEl.scrollTop = keyboardEl.scrollTop;
+      // Reset flag after the next animation frame to allow the other scroll event to process and be ignored
+      syncRafRef.current = requestAnimationFrame(() => {
+        isSyncingScroll.current = false;
+      });
+    };
+
+    const handlePianoRollScroll = () => {
+      if (syncRafRef.current) cancelAnimationFrame(syncRafRef.current);
+      if (isSyncingScroll.current) {
+        isSyncingScroll.current = false;
+        return;
+      }
+      isSyncingScroll.current = true;
+      keyboardEl.scrollTop = pianoRollEl.scrollTop;
+      syncRafRef.current = requestAnimationFrame(() => {
+        isSyncingScroll.current = false;
+      });
+    };
+
+    keyboardEl.addEventListener('scroll', handleKeyboardScroll);
+    pianoRollEl.addEventListener('scroll', handlePianoRollScroll);
+
+    return () => {
+      keyboardEl.removeEventListener('scroll', handleKeyboardScroll);
+      pianoRollEl.removeEventListener('scroll', handlePianoRollScroll);
+      if (syncRafRef.current) {
+        cancelAnimationFrame(syncRafRef.current);
+      }
+    };
+  }, []); // Empty dependency array: run once on mount
+
   return (
     <MusicDataProvider>
       <div className="app-container" style={{ padding: '20px', display: 'flex', flexDirection: 'column', height: 'calc(100vh - 40px)' /* Adjust for padding */ }}>
         <h1 style={{ textAlign: 'center', marginBottom: '20px', flexShrink: 0 }}>Music Editor Prototype</h1>
         <div className="main-content" style={{ display: 'flex', flexGrow: 1, overflow: 'hidden', alignItems: 'flex-start' /* Align items to the top */ }}>
-          <div className="keyboard-area" style={{ overflowY: 'auto', flexShrink: 0, height: '100%' /* Allow keyboard to scroll if taller than main-content */ }}>
+          <div ref={keyboardScrollRef} className="keyboard-area" style={{ overflowY: 'auto', flexShrink: 0, height: '100%' /* Allow keyboard to scroll if taller than main-content */ }}>
             <PianoKeyboard />
           </div>
-          <div className="pianoroll-area" style={{ flexGrow: 1, overflow: 'auto', height: '100%' /* Allow piano roll to scroll if taller */ }}>
+          <div ref={pianoRollScrollRef} className="pianoroll-area" style={{ flexGrow: 1, overflow: 'auto', height: '100%' /* Allow piano roll to scroll if taller */ }}>
             <PianoRoll />
           </div>
         </div>

--- a/src/components/Note.test.tsx
+++ b/src/components/Note.test.tsx
@@ -1,0 +1,163 @@
+// src/components/Note.test.tsx
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { vi } from 'vitest';
+import '@testing-library/jest-dom';
+import { NoteComponent } from './Note'; // Actual component name
+import { Note as NoteType } from '../types/music';
+
+const mockNote: NoteType = {
+  id: 'note1',
+  tick: 0,
+  pitch: 60, // C4
+  duration: 480, // Quarter note
+  lyric: 'Hello',
+  vel: 100,
+  gen: 0,
+};
+
+const mockOnSelect = vi.fn();
+const mockOnDelete = vi.fn();
+const mockOnUpdateLyric = vi.fn();
+
+const defaultProps = {
+  note: mockNote,
+  x: 10,
+  y: 50,
+  width: 100,
+  height: 20,
+  isSelected: false,
+  onSelect: mockOnSelect,
+  onDelete: mockOnDelete,
+  onUpdateLyric: mockOnUpdateLyric,
+};
+
+describe('NoteComponent', () => {
+  beforeEach(() => {
+    // Clear mock call counts before each test
+    mockOnSelect.mockClear();
+    mockOnDelete.mockClear();
+    mockOnUpdateLyric.mockClear();
+  });
+
+  test('renders with lyric', () => {
+    render(<NoteComponent {...defaultProps} />);
+    expect(screen.getByText('Hello')).toBeInTheDocument();
+  });
+
+  test('renders with pitch if no lyric', () => {
+    render(<NoteComponent {...defaultProps} note={{ ...mockNote, lyric: '' }} />);
+    expect(screen.getByText(`P:${mockNote.pitch}`)).toBeInTheDocument();
+  });
+
+  test('calls onSelect when clicked', () => {
+    render(<NoteComponent {...defaultProps} />);
+    const noteElement = screen.getByText('Hello');
+    fireEvent.click(noteElement);
+    expect(mockOnSelect).toHaveBeenCalledTimes(1);
+    expect(mockOnSelect).toHaveBeenCalledWith(mockNote.id);
+  });
+
+  test('shows selection style when isSelected is true', () => {
+    render(<NoteComponent {...defaultProps} isSelected={true} />);
+    const noteElement = screen.getByText('Hello').parentElement; // Get the div
+    expect(noteElement).toHaveStyle('background-color: lightblue');
+    expect(noteElement).toHaveStyle('border: 2px solid dodgerblue');
+  });
+
+  test('shows default style when isSelected is false', () => {
+    render(<NoteComponent {...defaultProps} isSelected={false} />);
+    const noteElement = screen.getByText('Hello').parentElement; // Get the div
+    expect(noteElement).toHaveStyle('background-color: cornflowerblue');
+    expect(noteElement).toHaveStyle('border: 1px solid black');
+  });
+
+  describe('Interactions for a selected note', () => {
+    test('calls onDelete when Delete key is pressed', async () => {
+      render(<NoteComponent {...defaultProps} isSelected={true} />);
+      const noteElement = screen.getByText('Hello').parentElement!;
+      noteElement.focus(); // Element must be focused to receive key events
+      await userEvent.keyboard('{Delete}');
+      expect(mockOnDelete).toHaveBeenCalledTimes(1);
+      expect(mockOnDelete).toHaveBeenCalledWith(mockNote.id);
+    });
+
+    test('calls onDelete when Backspace key is pressed', async () => {
+      render(<NoteComponent {...defaultProps} isSelected={true} />);
+      const noteElement = screen.getByText('Hello').parentElement!;
+      noteElement.focus();
+      await userEvent.keyboard('{Backspace}');
+      expect(mockOnDelete).toHaveBeenCalledTimes(1);
+      expect(mockOnDelete).toHaveBeenCalledWith(mockNote.id);
+    });
+
+    test('enters lyric edit mode on Enter key press', async () => {
+      render(<NoteComponent {...defaultProps} isSelected={true} />);
+      const noteElement = screen.getByText('Hello').parentElement!;
+      noteElement.focus();
+      await userEvent.keyboard('{Enter}');
+
+      const inputField = screen.getByRole('textbox');
+      expect(inputField).toBeInTheDocument();
+      expect(inputField).toHaveValue(mockNote.lyric);
+    });
+
+    test('updates lyric on Enter in edit mode', async () => {
+      render(<NoteComponent {...defaultProps} isSelected={true} />);
+      const noteElement = screen.getByText('Hello').parentElement!;
+      noteElement.focus();
+      await userEvent.keyboard('{Enter}'); // Enter edit mode
+
+      const inputField = screen.getByRole('textbox');
+      await userEvent.clear(inputField);
+      await userEvent.type(inputField, 'New Lyric');
+      await userEvent.keyboard('{Enter}'); // Confirm edit
+
+      expect(mockOnUpdateLyric).toHaveBeenCalledTimes(1);
+      expect(mockOnUpdateLyric).toHaveBeenCalledWith(mockNote.id, 'New Lyric');
+      expect(screen.queryByRole('textbox')).not.toBeInTheDocument(); // Input field should disappear
+      // The component itself updates its internal state for currentLyric,
+      // but the display will show note.lyric until the prop is updated by the parent.
+      // So, we check if the input is gone, and the callback was called.
+    });
+
+    test('cancels lyric edit on Escape key', async () => {
+      render(<NoteComponent {...defaultProps} isSelected={true} />);
+      const noteElement = screen.getByText('Hello').parentElement!;
+      noteElement.focus();
+      await userEvent.keyboard('{Enter}'); // Enter edit mode
+
+      const inputField = screen.getByRole('textbox');
+      await userEvent.clear(inputField);
+      await userEvent.type(inputField, 'Changed Lyric');
+      await userEvent.keyboard('{Escape}'); // Cancel edit
+
+      expect(mockOnUpdateLyric).not.toHaveBeenCalled();
+      expect(screen.queryByRole('textbox')).not.toBeInTheDocument(); // Input field should disappear
+      expect(screen.getByText('Hello')).toBeInTheDocument(); // Original lyric should remain or be restored
+    });
+
+    test('updates lyric on blur from input field', async () => {
+        render(<NoteComponent {...defaultProps} isSelected={true} />);
+        const noteElement = screen.getByText('Hello').parentElement!;
+        noteElement.focus();
+        await userEvent.keyboard('{Enter}'); // Enter edit mode
+
+        const inputField = screen.getByRole('textbox') as HTMLInputElement;
+        await userEvent.clear(inputField);
+        await userEvent.type(inputField, 'Updated on Blur');
+
+        // userEvent.tab() simulates the user pressing Tab, which should trigger blur.
+        // userEvent handles act() wrapper internally for its events.
+        await userEvent.tab();
+
+        // Check that onUpdateLyric was called (due to blur handler in NoteComponent)
+        expect(mockOnUpdateLyric).toHaveBeenCalledTimes(1);
+        expect(mockOnUpdateLyric).toHaveBeenCalledWith(mockNote.id, 'Updated on Blur');
+
+        // Check that the input field is no longer present
+        expect(screen.queryByRole('textbox')).not.toBeInTheDocument();
+      });
+  });
+});

--- a/src/components/Note.tsx
+++ b/src/components/Note.tsx
@@ -1,0 +1,135 @@
+// src/components/Note.tsx
+import React, { useState, useEffect, useRef } from 'react';
+import { Note as NoteType } from '../types/music'; // Assuming NoteType includes id, lyric etc.
+
+interface NoteProps {
+  note: NoteType;
+  x: number; // Position x on the piano roll
+  y: number; // Position y on the piano roll (derived from pitch)
+  width: number; // Visual width (derived from duration)
+  height: number; // Visual height (e.g., NOTE_HEIGHT from PianoRoll)
+  isSelected: boolean;
+  onSelect: (noteId: string) => void;
+  onDelete: (noteId: string) => void;
+  onUpdateLyric: (noteId: string, newLyric: string) => void;
+}
+
+export const NoteComponent: React.FC<NoteProps> = ({
+  note,
+  x,
+  y,
+  width,
+  height,
+  isSelected,
+  onSelect,
+  onDelete,
+  onUpdateLyric,
+}) => {
+  const [isEditingLyric, setIsEditingLyric] = useState(false);
+  const [currentLyric, setCurrentLyric] = useState(note.lyric);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    setCurrentLyric(note.lyric); // Sync if prop changes
+  }, [note.lyric]);
+
+  useEffect(() => {
+    if (isSelected && inputRef.current) {
+      inputRef.current.focus();
+    }
+  }, [isEditingLyric, isSelected]);
+
+
+  const handleNoteClick = (e: React.MouseEvent) => {
+    e.stopPropagation(); // Prevent PianoRoll click handling if any
+    onSelect(note.id);
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    e.stopPropagation();
+    if (!isSelected) return;
+
+    if (e.key === 'Delete' || e.key === 'Backspace') {
+      onDelete(note.id);
+      console.log(`Delete requested for note ${note.id}`);
+    } else if (e.key === 'Enter') {
+      if (isEditingLyric) {
+        onUpdateLyric(note.id, currentLyric);
+        console.log(`Lyric update for note ${note.id}: ${currentLyric}`);
+      }
+      setIsEditingLyric(!isEditingLyric); // Toggle edit mode or commit
+    } else if (e.key === 'Escape') {
+      if (isEditingLyric) {
+        setCurrentLyric(note.lyric); // Revert changes
+        setIsEditingLyric(false);
+        console.log(`Lyric edit cancelled for note ${note.id}`);
+      }
+    }
+  };
+
+  const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setCurrentLyric(e.target.value);
+  };
+
+  const handleInputKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    e.stopPropagation(); // Prevent note's main keydown handler
+    if (e.key === 'Enter') {
+      onUpdateLyric(note.id, currentLyric);
+      setIsEditingLyric(false);
+      console.log(`Lyric update for note ${note.id} from input: ${currentLyric}`);
+    } else if (e.key === 'Escape') {
+      setCurrentLyric(note.lyric); // Revert
+      setIsEditingLyric(false);
+      console.log(`Lyric edit cancelled for note ${note.id} from input`);
+    }
+  };
+
+
+  const noteStyle: React.CSSProperties = {
+    position: 'absolute',
+    left: x,
+    top: y,
+    width: width,
+    height: height,
+    backgroundColor: isSelected ? 'lightblue' : 'cornflowerblue',
+    border: isSelected ? '2px solid dodgerblue' : '1px solid black',
+    boxSizing: 'border-box',
+    cursor: 'pointer',
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    fontSize: '10px',
+    color: 'white',
+    overflow: 'hidden',
+    whiteSpace: 'nowrap',
+    textOverflow: 'ellipsis',
+  };
+
+  return (
+    <div
+      style={noteStyle}
+      onClick={handleNoteClick}
+      onKeyDown={isEditingLyric ? undefined : handleKeyDown} // Only handle main keydown if not editing lyric in input
+      tabIndex={0} // Make it focusable
+      title={`Tick: ${note.tick}, Pitch: ${note.pitch}, Lyric: ${note.lyric}`}
+    >
+      {isEditingLyric ? (
+        <input
+          ref={inputRef}
+          type="text"
+          value={currentLyric}
+          onChange={handleInputChange}
+          onKeyDown={handleInputKeyDown}
+          onBlur={() => { // Commit on blur as well, or revert
+            onUpdateLyric(note.id, currentLyric);
+            setIsEditingLyric(false);
+            console.log(`Lyric update for note ${note.id} on blur: ${currentLyric}`);
+          }}
+          style={{ width: '90%', fontSize: '10px', boxSizing: 'border-box' }}
+        />
+      ) : (
+        <span>{note.lyric || `P:${note.pitch}`}</span>
+      )}
+    </div>
+  );
+};

--- a/src/components/PianoKeyboard.test.tsx
+++ b/src/components/PianoKeyboard.test.tsx
@@ -7,7 +7,7 @@ import { PianoKeyboard } from './PianoKeyboard';
 // Updated constants to reflect vertical layout and new dimensions
 const KEY_HEIGHT = 12; // px
 const WHITE_KEY_DEPTH = 80; // px
-const BLACK_KEY_DEPTH = 50; // px
+const BLACK_KEY_DEPTH = 80; // px (now same as white key depth)
 const NUM_KEYS = 128;
 const C4_MIDI_NOTE = 60;
 
@@ -73,22 +73,28 @@ describe('PianoKeyboard', () => {
   test('distinguishes between black and white keys by style', () => {
     render(<PianoKeyboard />);
     const c4Details = getNoteDetails(C4_MIDI_NOTE); // C4 (white)
-    const c4Key = screen.getByTitle(c4Details.name);
+    const c4Key = screen.getByTitle(c4Details.name); // C4 is a white key
     expect(c4Key).toHaveStyle('background-color: gold'); // C4 is highlighted
     expect(c4Key).toHaveStyle(`height: ${KEY_HEIGHT}px`);
     expect(c4Key).toHaveStyle(`width: ${WHITE_KEY_DEPTH}px`);
+    expect(c4Key).toHaveStyle('border-left: 1px solid #333');
+    expect(c4Key).toHaveStyle('border-right: 1px solid #333');
+    expect(c4Key).toHaveStyle('border-top: 1px solid #333');
+    expect(c4Key).toHaveStyle('border-bottom: 1px solid #ccc'); // Specific white key bottom border
 
-    const d4Details = getNoteDetails(62); // D4 (white, not highlighted)
+    const d4Details = getNoteDetails(62); // D4 (another white key, not highlighted)
     const d4Key = screen.getByTitle(d4Details.name);
     expect(d4Key).toHaveStyle('background-color: white');
     expect(d4Key).toHaveStyle(`height: ${KEY_HEIGHT}px`);
     expect(d4Key).toHaveStyle(`width: ${WHITE_KEY_DEPTH}px`);
+    expect(d4Key).toHaveStyle('border-bottom: 1px solid #ccc');
 
-    const cs4Details = getNoteDetails(61); // C#4 (black)
+    const cs4Details = getNoteDetails(61); // C#4 (black key)
     const cs4Key = screen.getByTitle(cs4Details.name);
     expect(cs4Key).toHaveStyle('background-color: black');
     expect(cs4Key).toHaveStyle(`height: ${KEY_HEIGHT}px`);
-    expect(cs4Key).toHaveStyle(`width: ${BLACK_KEY_DEPTH}px`);
+    expect(cs4Key).toHaveStyle(`width: ${BLACK_KEY_DEPTH}px`); // Now same as white key depth
+    expect(cs4Key).toHaveStyle('border-bottom: 1px solid #333'); // Black keys have the standard #333 bottom border
     expect(cs4Key).toHaveStyle('z-index: 1');
   });
 });

--- a/src/components/PianoKeyboard.test.tsx
+++ b/src/components/PianoKeyboard.test.tsx
@@ -1,0 +1,93 @@
+// src/components/PianoKeyboard.test.tsx
+import React from 'react';
+import { render, screen, within } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { PianoKeyboard } from './PianoKeyboard';
+
+// Constants from PianoKeyboard.tsx (consider exporting them from the component file for DRYness)
+const WHITE_KEY_WIDTH = 22; // px
+const BLACK_KEY_WIDTH = 13; // px
+const NUM_KEYS = 128;
+const C4_MIDI_NOTE = 60;
+
+// Helper to get note details, simplified or imported if possible
+const noteNames = ['C', 'C#', 'D', 'D#', 'E', 'F', 'F#', 'G', 'G#', 'A', 'A#', 'B'];
+const getNoteDetails = (midiNote: number) => {
+  const octave = Math.floor(midiNote / 12) - 1;
+  const noteIndex = midiNote % 12;
+  const name = noteNames[noteIndex];
+  const isBlack = name.includes('#');
+  return {
+    name: `${name}${octave}`,
+    isBlack,
+  };
+};
+
+describe('PianoKeyboard', () => {
+  test('renders all 128 keys', () => {
+    render(<PianoKeyboard />);
+    // White keys + Black keys.
+    // The component renders white keys and black keys as separate collections of divs,
+    // each with its own logic for counting.
+    // Let's count how many white keys there are:
+    let whiteKeyCount = 0;
+    for (let i = 0; i < NUM_KEYS; i++) {
+      if (!getNoteDetails(i).isBlack) {
+        whiteKeyCount++;
+      }
+    }
+    // All keys are rendered as divs with a title attribute being the note name
+    const allKeyElements = screen.getAllByTitle(/^[A-G]#?[0-9-]/); // Matches C4, C#-1, G8 etc.
+    expect(allKeyElements.length).toBe(NUM_KEYS);
+  });
+
+  test('highlights C4 (MIDI note 60)', () => {
+    render(<PianoKeyboard />);
+    const c4Details = getNoteDetails(C4_MIDI_NOTE); // C4
+    const c4Key = screen.getByTitle(c4Details.name);
+    // Highlighted keys have a 'gold' background color
+    expect(c4Key).toHaveStyle('background-color: gold');
+  });
+
+  test('displays correct note names for sample keys', () => {
+    render(<PianoKeyboard />);
+
+    const c4Details = getNoteDetails(C4_MIDI_NOTE); // C4
+    expect(screen.getByTitle(c4Details.name)).toBeInTheDocument();
+    // Check for the shortened label inside the key
+    expect(screen.getByText(c4Details.name)).toBeInTheDocument();
+
+
+    const a4Details = getNoteDetails(69); // A4
+    expect(screen.getByTitle(a4Details.name)).toBeInTheDocument();
+    expect(screen.getByText(a4Details.name)).toBeInTheDocument();
+
+    const cs5Details = getNoteDetails(73); // C#5
+    const cs5KeyElement = screen.getByTitle(cs5Details.name);
+    expect(cs5KeyElement).toBeInTheDocument();
+    // Black key labels are shortened, e.g., "C#5" becomes "C#"
+    // Check within the specific C#5 key element for its shortened label
+    expect(within(cs5KeyElement).getByText(cs5Details.name.substring(0,2))).toBeInTheDocument();
+  });
+
+  test('distinguishes between black and white keys by style', () => {
+    render(<PianoKeyboard />);
+    const c4Details = getNoteDetails(C4_MIDI_NOTE); // C4 (white)
+    const c4Key = screen.getByTitle(c4Details.name);
+    expect(c4Key).toHaveStyle('background-color: gold'); // C4 is highlighted, so gold
+    expect(c4Key).toHaveStyle(`height: 120px`); // WHITE_KEY_HEIGHT
+
+    const d4Details = getNoteDetails(62); // D4 (white, not highlighted)
+    const d4Key = screen.getByTitle(d4Details.name);
+    expect(d4Key).toHaveStyle('background-color: white');
+    expect(d4Key).toHaveStyle(`height: 120px`); // WHITE_KEY_HEIGHT
+
+
+    const cs4Details = getNoteDetails(61); // C#4 (black)
+    const cs4Key = screen.getByTitle(cs4Details.name);
+    expect(cs4Key).toHaveStyle('background-color: black');
+    expect(cs4Key).toHaveStyle(`height: 75px`); // BLACK_KEY_HEIGHT
+    expect(cs4Key).toHaveStyle(`width: ${BLACK_KEY_WIDTH}px`);
+    expect(cs4Key).toHaveStyle('z-index: 1'); // Black keys should be above white keys
+  });
+});

--- a/src/components/PianoKeyboard.test.tsx
+++ b/src/components/PianoKeyboard.test.tsx
@@ -4,9 +4,10 @@ import { render, screen, within } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import { PianoKeyboard } from './PianoKeyboard';
 
-// Constants from PianoKeyboard.tsx (consider exporting them from the component file for DRYness)
-const WHITE_KEY_WIDTH = 22; // px
-const BLACK_KEY_WIDTH = 13; // px
+// Updated constants to reflect vertical layout and new dimensions
+const KEY_HEIGHT = 12; // px
+const WHITE_KEY_DEPTH = 80; // px
+const BLACK_KEY_DEPTH = 50; // px
 const NUM_KEYS = 128;
 const C4_MIDI_NOTE = 60;
 
@@ -65,29 +66,29 @@ describe('PianoKeyboard', () => {
     const cs5Details = getNoteDetails(73); // C#5
     const cs5KeyElement = screen.getByTitle(cs5Details.name);
     expect(cs5KeyElement).toBeInTheDocument();
-    // Black key labels are shortened, e.g., "C#5" becomes "C#"
-    // Check within the specific C#5 key element for its shortened label
-    expect(within(cs5KeyElement).getByText(cs5Details.name.substring(0,2))).toBeInTheDocument();
+    // Component now displays full label for black keys as well
+    expect(within(cs5KeyElement).getByText(cs5Details.name)).toBeInTheDocument();
   });
 
   test('distinguishes between black and white keys by style', () => {
     render(<PianoKeyboard />);
     const c4Details = getNoteDetails(C4_MIDI_NOTE); // C4 (white)
     const c4Key = screen.getByTitle(c4Details.name);
-    expect(c4Key).toHaveStyle('background-color: gold'); // C4 is highlighted, so gold
-    expect(c4Key).toHaveStyle(`height: 120px`); // WHITE_KEY_HEIGHT
+    expect(c4Key).toHaveStyle('background-color: gold'); // C4 is highlighted
+    expect(c4Key).toHaveStyle(`height: ${KEY_HEIGHT}px`);
+    expect(c4Key).toHaveStyle(`width: ${WHITE_KEY_DEPTH}px`);
 
     const d4Details = getNoteDetails(62); // D4 (white, not highlighted)
     const d4Key = screen.getByTitle(d4Details.name);
     expect(d4Key).toHaveStyle('background-color: white');
-    expect(d4Key).toHaveStyle(`height: 120px`); // WHITE_KEY_HEIGHT
-
+    expect(d4Key).toHaveStyle(`height: ${KEY_HEIGHT}px`);
+    expect(d4Key).toHaveStyle(`width: ${WHITE_KEY_DEPTH}px`);
 
     const cs4Details = getNoteDetails(61); // C#4 (black)
     const cs4Key = screen.getByTitle(cs4Details.name);
     expect(cs4Key).toHaveStyle('background-color: black');
-    expect(cs4Key).toHaveStyle(`height: 75px`); // BLACK_KEY_HEIGHT
-    expect(cs4Key).toHaveStyle(`width: ${BLACK_KEY_WIDTH}px`);
-    expect(cs4Key).toHaveStyle('z-index: 1'); // Black keys should be above white keys
+    expect(cs4Key).toHaveStyle(`height: ${KEY_HEIGHT}px`);
+    expect(cs4Key).toHaveStyle(`width: ${BLACK_KEY_DEPTH}px`);
+    expect(cs4Key).toHaveStyle('z-index: 1');
   });
 });

--- a/src/components/PianoKeyboard.tsx
+++ b/src/components/PianoKeyboard.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 
 const KEY_HEIGHT = 12; // px - Synchronized with PianoRoll's NOTE_LANE_HEIGHT
 const WHITE_KEY_DEPTH = 80; // px - Visual width of white keys in vertical layout
-const BLACK_KEY_DEPTH = 50; // px - Visual width of black keys
+const BLACK_KEY_DEPTH = 80; // px - Visual width of black keys, now same as white keys
 
 const NUM_KEYS = 128; // MIDI notes 0-127
 const C4_MIDI_NOTE = 60;
@@ -42,7 +42,10 @@ const PianoKeyDisplay: React.FC<PianoKeyDisplayProps> = ({ details, isHighlighte
   const keyStyle: React.CSSProperties = {
     ...style,
     backgroundColor: details.isBlack ? 'black' : 'white',
-    border: '1px solid #333',
+    borderLeft: '1px solid #333',
+    borderRight: '1px solid #333',
+    borderTop: '1px solid #333', // Default top border for all keys
+    borderBottom: details.isBlack ? '1px solid #333' : '1px solid #ccc', // Thinner bottom border for white keys
     boxSizing: 'border-box',
     color: details.isBlack ? 'white' : 'black',
     display: 'flex',
@@ -100,12 +103,13 @@ export const PianoKeyboard: React.FC = () => {
       // They are typically inset. For now, let's place them at the same left edge but with different width.
       // A common vertical style is to have black keys narrower and starting at the same horizontal line as white keys.
       // Or, they could be visually "on top" if white keys are made narrower.
-      // For simplicity, black keys will be less deep and start at same horizontal origin.
-      keySpecificStyle.zIndex = 1; // Ensure black keys are visually on top if any overlap logic added
+    // For simplicity, black keys will have the same depth and start at same horizontal origin.
+    // Their zIndex and color will differentiate them.
+    keySpecificStyle.zIndex = 1;
     } else {
+      // White keys
       keySpecificStyle.width = `${WHITE_KEY_DEPTH}px`;
       keySpecificStyle.top = `${(NUM_KEYS - 1 - i) * KEY_HEIGHT}px`;
-      // currentWhiteKeyTop += KEY_HEIGHT; // This logic changes as top is absolute by pitch
     }
 
     keysToRender.push(
@@ -122,11 +126,9 @@ export const PianoKeyboard: React.FC = () => {
   const totalKeyboardWidth = WHITE_KEY_DEPTH; // Dominated by white key depth
 
   return (
-    <div style={{ border: '1px solid blue', padding: '5px', height: `${totalKeyboardHeight + 10}px`, width: `${totalKeyboardWidth + 10 + 40}px`, position: 'relative', margin: '0', overflowY: 'auto', overflowX: 'hidden' }}>
-      {/* Added width for title */}
-      <h3 style={{ writingMode: 'vertical-rl', textOrientation: 'mixed', textAlign: 'center', margin: `0 0 0 ${totalKeyboardWidth}px`, height: `${totalKeyboardHeight}px`, position: 'absolute', right: '5px', top: '5px' }}>
-        Piano Keyboard
-      </h3>
+    <div style={{ border: '1px solid blue', /* padding: '5px', */ height: `${totalKeyboardHeight}px`, width: `${totalKeyboardWidth}px`, position: 'relative', margin: '0', overflowY: 'auto', overflowX: 'hidden' }}>
+      {/* Title h3 element removed */}
+      {/* Container size adjusted to remove padding allowance */}
       <div style={{ position: 'relative', width: `${totalKeyboardWidth}px`, height: `${totalKeyboardHeight}px` }}>
         {keysToRender}
       </div>

--- a/src/components/PianoKeyboard.tsx
+++ b/src/components/PianoKeyboard.tsx
@@ -1,0 +1,132 @@
+// src/components/PianoKeyboard.tsx
+import React from 'react';
+
+const WHITE_KEY_WIDTH = 22; // px
+const WHITE_KEY_HEIGHT = 120; // px
+const BLACK_KEY_WIDTH = 13; // px
+const BLACK_KEY_HEIGHT = 75; // px
+const NUM_KEYS = 128; // MIDI notes 0-127
+const C4_MIDI_NOTE = 60;
+
+const noteNames = ['C', 'C#', 'D', 'D#', 'E', 'F', 'F#', 'G', 'G#', 'A', 'A#', 'B'];
+
+interface NoteDetails {
+  name: string;
+  isBlack: boolean;
+  octave: number;
+  noteInOctave: number; // 0 for C, 1 for C#, ..., 11 for B
+}
+
+const getNoteDetails = (midiNote: number): NoteDetails => {
+  const octave = Math.floor(midiNote / 12) - 1; // MIDI note 0 is C-1
+  const noteIndex = midiNote % 12;
+  const name = noteNames[noteIndex];
+  const isBlack = name.includes('#');
+  return {
+    name: `${name}${octave}`,
+    isBlack,
+    octave,
+    noteInOctave: noteIndex,
+  };
+};
+
+interface PianoKeyProps {
+  details: NoteDetails;
+  isHighlighted: boolean;
+  left: number;
+  top?: number; // Only for black keys
+}
+
+const PianoKeyDisplay: React.FC<PianoKeyProps> = ({ details, isHighlighted, left, top = 0 }) => {
+  const keyStyle: React.CSSProperties = {
+    position: 'absolute',
+    left: `${left}px`,
+    top: `${top}px`,
+    width: `${details.isBlack ? BLACK_KEY_WIDTH : WHITE_KEY_WIDTH}px`,
+    height: `${details.isBlack ? BLACK_KEY_HEIGHT : WHITE_KEY_HEIGHT}px`,
+    backgroundColor: details.isBlack ? 'black' : 'white',
+    border: '1px solid #333',
+    boxSizing: 'border-box',
+    color: details.isBlack ? 'white' : 'black',
+    display: 'flex',
+    flexDirection: 'column',
+    justifyContent: 'flex-end',
+    alignItems: 'center',
+    paddingBottom: '5px',
+    fontSize: '8px',
+    zIndex: details.isBlack ? 1 : 0,
+    transition: 'background-color 0.1s ease', // For potential future hover effects
+  };
+
+  if (isHighlighted) {
+    keyStyle.backgroundColor = 'gold'; // Highlight C4
+    keyStyle.color = 'black';
+  }
+
+  // Shorten label: C#4 -> C#, C4 -> C4
+  const displayLabel = details.name.length > 2 && details.isBlack ?
+                       details.name.substring(0, 2) :
+                       details.name;
+
+  return (
+    <div style={keyStyle} title={details.name}>
+      <span>{displayLabel}</span>
+    </div>
+  );
+};
+
+export const PianoKeyboard: React.FC = () => {
+  const whiteKeys = [];
+  const blackKeys = [];
+  let currentWhiteKeyLeft = 0;
+
+  // First pass: layout white keys and create black key data
+  for (let i = 0; i < NUM_KEYS; i++) {
+    const details = getNoteDetails(i);
+    const isHighlighted = i === C4_MIDI_NOTE;
+
+    if (!details.isBlack) {
+      whiteKeys.push(
+        <PianoKeyDisplay
+          key={`wk-${i}`}
+          details={details}
+          isHighlighted={isHighlighted}
+          left={currentWhiteKeyLeft}
+        />
+      );
+      // Prepare for black keys associated with this white key
+      // C#(1), D#(3), F#(6), G#(8), A#(10)
+      // Black keys are positioned relative to the white key they follow.
+      // The offset is typically a bit more than half the white key's width.
+      if ([0, 2, 5, 7, 9].includes(details.noteInOctave)) { // C, D, F, G, A
+         // Check if the next note is within range and is black
+        if (i + 1 < NUM_KEYS) {
+            const nextNoteDetails = getNoteDetails(i + 1);
+            if (nextNoteDetails.isBlack) {
+                 blackKeys.push(
+                    <PianoKeyDisplay
+                        key={`bk-${i + 1}`}
+                        details={nextNoteDetails}
+                        isHighlighted={(i + 1) === C4_MIDI_NOTE} // Should not happen for C4
+                        left={currentWhiteKeyLeft + WHITE_KEY_WIDTH - (BLACK_KEY_WIDTH / 2) -1} // Center on the line
+                    />
+                );
+            }
+        }
+      }
+      currentWhiteKeyLeft += WHITE_KEY_WIDTH;
+    }
+  }
+
+  const totalWidth = currentWhiteKeyLeft; // Total width is based on white keys
+
+  return (
+    <div style={{ border: '1px solid blue', padding: '10px', height: `${WHITE_KEY_HEIGHT + 50}px`, position: 'relative', width: `${totalWidth}px`, margin: '20px 0', overflowX: 'auto', overflowY: 'hidden' }}>
+      <h3 style={{ textAlign: 'center', margin: '0 0 10px 0' }}>Piano Keyboard</h3>
+      <div style={{ position: 'relative', width: `${totalWidth}px`, height: `${WHITE_KEY_HEIGHT}px` }}>
+        {whiteKeys}
+        {blackKeys}
+      </div>
+    </div>
+  );
+};

--- a/src/components/PianoRoll.test.tsx
+++ b/src/components/PianoRoll.test.tsx
@@ -77,13 +77,27 @@ vi.mock('../contexts/MusicDataContext', () => ({
   useMusicData: vi.fn(),
 }));
 
-global.HTMLCanvasElement.prototype.getContext = vi.fn(() => ({
+global.HTMLCanvasElement.prototype.getContext = vi.fn(() => {
+  let currentFillStyle = '';
+  return {
     clearRect: vi.fn(),
     beginPath: vi.fn(),
     moveTo: vi.fn(),
     lineTo: vi.fn(),
     stroke: vi.fn(),
-})) as any;
+    fillRect: vi.fn(),
+    strokeRect: vi.fn(), // Added as it's used in PianoRoll
+    get fillStyle() {
+      return currentFillStyle;
+    },
+    set fillStyle(style: string) {
+      currentFillStyle = style;
+    },
+    // Mock other properties or methods if they are accessed or called
+    lineWidth: 0, // Default value
+    strokeStyle: '', // Default value
+  };
+}) as any;
 
 describe('PianoRoll', () => {
   beforeEach(() => {

--- a/src/components/PianoRoll.test.tsx
+++ b/src/components/PianoRoll.test.tsx
@@ -1,0 +1,181 @@
+// src/components/PianoRoll.test.tsx
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { vi } from 'vitest';
+import '@testing-library/jest-dom';
+
+import { PianoRoll } from './PianoRoll';
+import { Note as NoteType } from '../types/music';
+import { MusicDataContextType, useMusicData } from '../contexts/MusicDataContext';
+
+// Import the component to be mocked. After vi.mock, this will be the mock itself.
+import { NoteComponent } from './Note';
+
+// Mock the './Note' module.
+// The factory function defines the mock implementation.
+vi.mock('./Note', async (importOriginal) => {
+  const actual = await importOriginal() as any; // Import actual if needed for passthrough
+  return {
+    ...actual, // Spread actual module exports if you want to mock only specific parts
+    __esModule: true,
+    NoteComponent: vi.fn(({ note, isSelected, onSelect, onDelete }) => (
+      <div
+        data-testid={`note-${note.id}`}
+        data-selected={isSelected}
+        onClick={() => onSelect(note.id)}
+        onKeyDown={(e) => {
+          if (e.key === 'Delete' || e.key === 'Backspace') {
+            onDelete(note.id);
+          }
+        }}
+        tabIndex={0}
+        role="button"
+      >
+        {note.lyric || `P:${note.pitch}`}
+      </div>
+    )),
+  };
+});
+
+// Cast the imported NoteComponent to its mocked type (Vitest.MockedFunction)
+// This allows us to use .mockClear(), .toHaveBeenCalledTimes(), etc.
+const MockedNoteComponent = NoteComponent as ReturnType<typeof vi.fn>;
+
+const initialMockNotes = new Map<string, NoteType>([
+  ['note1', { id: 'note1', tick: 0, pitch: 60, duration: 480, lyric: 'N1', vel: 100, gen:0 }],
+  ['note2', { id: 'note2', tick: 240, pitch: 62, duration: 240, lyric: 'N2', vel: 100, gen:0 }],
+]);
+
+let currentMockNotesState: Map<string, NoteType>; // Will be reset in beforeEach
+
+const mockDeleteNote = vi.fn((noteId: string) => {
+  // Create a new Map instance when a note is deleted
+  const newNotes = new Map(currentMockNotesState);
+  newNotes.delete(noteId);
+  currentMockNotesState = newNotes; // Update to the new Map instance
+});
+const mockUpdateNote = vi.fn();
+const mockAddNote = vi.fn();
+const mockGetNoteById = vi.fn((id: string) => currentMockNotesState.get(id));
+
+const mockUseMusicDataContext: () => MusicDataContextType = () => ({
+  notes: currentMockNotesState,
+  deleteNote: mockDeleteNote,
+  updateNote: mockUpdateNote,
+  addNote: mockAddNote,
+  getNoteById: mockGetNoteById,
+  events: new Map(),
+  addEvent: vi.fn(),
+  updateEvent: vi.fn(),
+  deleteEvent: vi.fn(),
+  getEventById: vi.fn(),
+});
+
+vi.mock('../contexts/MusicDataContext', () => ({
+  ...vi.importActual('../contexts/MusicDataContext'),
+  useMusicData: vi.fn(),
+}));
+
+global.HTMLCanvasElement.prototype.getContext = vi.fn(() => ({
+    clearRect: vi.fn(),
+    beginPath: vi.fn(),
+    moveTo: vi.fn(),
+    lineTo: vi.fn(),
+    stroke: vi.fn(),
+})) as any;
+
+describe('PianoRoll', () => {
+  beforeEach(() => {
+    currentMockNotesState = new Map(JSON.parse(JSON.stringify(Array.from(initialMockNotes))));
+
+    mockDeleteNote.mockClear();
+    mockUpdateNote.mockClear();
+    mockAddNote.mockClear();
+    mockGetNoteById.mockClear();
+    MockedNoteComponent.mockClear(); // Clear the imported mock
+
+    (useMusicData as ReturnType<typeof vi.fn>).mockImplementation(mockUseMusicDataContext);
+  });
+
+  test('renders canvas element', () => {
+    render(<PianoRoll />);
+    expect(screen.getByRole('graphics-canvas')).toBeInTheDocument();
+  });
+
+  test('renders NoteDisplay components for each note from useMusicData', () => {
+    render(<PianoRoll />);
+    expect(MockedNoteComponent).toHaveBeenCalledTimes(currentMockNotesState.size);
+
+    currentMockNotesState.forEach(note => {
+      expect(screen.getByTestId(`note-${note.id}`)).toBeInTheDocument();
+      expect(screen.getByText(note.lyric!)).toBeInTheDocument();
+    });
+  });
+
+  test('clicking a NoteDisplay component selects it', () => {
+    render(<PianoRoll />);
+    const note1MockElement = screen.getByTestId('note-note1');
+    fireEvent.click(note1MockElement);
+
+    const calls = MockedNoteComponent.mock.calls;
+    const lastNote1CallProps = calls.slice().reverse().find(call => call[0].note.id === 'note1')[0];
+    const lastNote2CallProps = calls.slice().reverse().find(call => call[0].note.id === 'note2')[0];
+
+    expect(lastNote1CallProps.isSelected).toBe(true);
+    expect(lastNote2CallProps.isSelected).toBe(false);
+  });
+
+  test('clicking the canvas background deselects any selected note', () => {
+    render(<PianoRoll />);
+    const note1MockElement = screen.getByTestId('note-note1');
+    fireEvent.click(note1MockElement);
+
+    let calls = MockedNoteComponent.mock.calls;
+    let lastNote1CallProps = calls.slice().reverse().find(call => call[0].note.id === 'note1')[0];
+    expect(lastNote1CallProps.isSelected).toBe(true);
+
+    const canvasElement = screen.getByRole('graphics-canvas');
+    fireEvent.click(canvasElement);
+
+    calls = MockedNoteComponent.mock.calls;
+    lastNote1CallProps = calls.slice().reverse().find(call => call[0].note.id === 'note1')[0];
+    const lastNote2CallProps = calls.slice().reverse().find(call => call[0].note.id === 'note2')[0];
+
+    expect(lastNote1CallProps.isSelected).toBe(false);
+    expect(lastNote2CallProps.isSelected).toBe(false);
+  });
+
+  test('deleting a selected note via NoteDisplay calls deleteNote and clears selection', async () => {
+    render(<PianoRoll />);
+    const note1MockElement = screen.getByTestId('note-note1');
+    fireEvent.click(note1MockElement);
+
+    let calls = MockedNoteComponent.mock.calls;
+    let lastNote1CallProps = calls.slice().reverse().find(call => call[0].note.id === 'note1')[0];
+    expect(lastNote1CallProps.isSelected).toBe(true);
+
+    const noteToFocus = screen.getByTestId('note-note1');
+    noteToFocus.focus();
+    await userEvent.keyboard('{Delete}');
+
+    expect(mockDeleteNote).toHaveBeenCalledWith('note1');
+
+    // After deletion and re-render, the note element for note1 should not exist
+    expect(screen.queryByTestId('note-note1')).not.toBeInTheDocument();
+
+    // Note2 should still be present and not selected
+    const note2Element = screen.queryByTestId('note-note2');
+    expect(note2Element).toBeInTheDocument();
+
+    calls = MockedNoteComponent.mock.calls; // Re-assign to existing 'calls' variable
+    // Find the latest call for note2 to check its isSelected status
+    // It's possible note2 was rendered multiple times (before and after deletion of note1)
+    // We care about its state in the most recent render where it appears.
+    const lastNote2Call = calls.slice().reverse().find(call => call[0].note.id === 'note2');
+    expect(lastNote2Call).toBeDefined(); // Ensure note2 was rendered
+    if (lastNote2Call) {
+      expect(lastNote2Call[0].isSelected).toBe(false);
+    }
+  });
+});

--- a/src/components/PianoRoll.tsx
+++ b/src/components/PianoRoll.tsx
@@ -13,7 +13,7 @@ const CANVAS_HEIGHT = NUM_PITCHES * NOTE_LANE_HEIGHT;
 
 const PIXELS_PER_TICK = 0.1; // Determines horizontal scale of notes
 const TICKS_PER_BEAT = 480; // Standard ticks per beat, for visual grid reference
-const BEAT_WIDTH = TICKS_PER_BEAT * PIXELS_PER_TICK; // Width of a beat in pixels
+// const BEAT_WIDTH = TICKS_PER_BEAT * PIXELS_PER_TICK; // Width of a beat in pixels // Unused
 // const NUM_MEASURES_DISPLAY = 4; // Example: display 4 measures // Unused
 // const MEASURE_WIDTH = BEAT_WIDTH * 4; // Assuming 4 beats per measure // Unused
 
@@ -120,8 +120,8 @@ export const PianoRoll: React.FC = () => {
   const notesArray = Array.from(notes.values());
 
   return (
-    <div style={{ border: '1px solid green', padding: '10px', overflow: 'auto', position: 'relative' }}>
-      <h2 style={{ position: 'sticky', top: 0, left: 0, background: 'rgba(255,255,255,0.8)', zIndex: 10 }}>Piano Roll Area</h2>
+    <div style={{ border: '1px solid green', /* padding: '10px', */ overflow: 'auto', position: 'relative' }}>
+      {/* <h2 style={{ position: 'sticky', top: 0, left: 0, background: 'rgba(255,255,255,0.8)', zIndex: 10 }}>Piano Roll Area</h2> */}
       <div style={{ position: 'relative', width: CANVAS_WIDTH, height: CANVAS_HEIGHT }}>
         <canvas
           ref={canvasRef}

--- a/src/components/PianoRoll.tsx
+++ b/src/components/PianoRoll.tsx
@@ -1,36 +1,144 @@
 // src/components/PianoRoll.tsx
-import React from 'react';
+import React, { useRef, useEffect, useState } from 'react';
 import { useMusicData } from '../contexts/MusicDataContext';
-import { Note } from '../types/music';
+import { Note as NoteType } from '../types/music';
+import { NoteComponent as NoteDisplay } from './Note'; // Renamed to avoid conflict
+
+// Constants for rendering notes and canvas grid.
+// These should be consistent.
+const CANVAS_WIDTH = 1600; // Example width, can be dynamic
+const NOTE_LANE_HEIGHT = 12; // Height for each note lane (pitch)
+const NUM_PITCHES = 128; // MIDI pitch range 0-127
+const CANVAS_HEIGHT = NUM_PITCHES * NOTE_LANE_HEIGHT;
+
+const PIXELS_PER_TICK = 0.1; // Determines horizontal scale of notes
+const TICKS_PER_BEAT = 480; // Standard ticks per beat, for visual grid reference
+const BEAT_WIDTH = TICKS_PER_BEAT * PIXELS_PER_TICK; // Width of a beat in pixels
+const NUM_MEASURES_DISPLAY = 4; // Example: display 4 measures
+const MEASURE_WIDTH = BEAT_WIDTH * 4; // Assuming 4 beats per measure
+
+// Adjust CANVAS_WIDTH to show a certain number of measures/beats
+// const DYNAMIC_CANVAS_WIDTH = MEASURE_WIDTH * NUM_MEASURES_DISPLAY;
+// For now, using fixed CANVAS_WIDTH, but this could be calculated based on content.
 
 export const PianoRoll: React.FC = () => {
-  const { notes, deleteNote, addNote } = useMusicData();
+  const { notes, deleteNote, updateNote } = useMusicData();
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+  const [selectedNoteId, setSelectedNoteId] = useState<string | null>(null);
 
-  // Example: Function to add a sample note
-  const handleAddSampleNote = () => {
-    addNote({
-      tick: Math.floor(Math.random() * 1920), // Random tick
-      pitch: 60 + Math.floor(Math.random() * 24), // Random pitch around C4
-      duration: 480, // Quarter note in ticks (assuming 480 ticks per beat)
-      lyric: 'ら',
-      vel: 100,
-      gen: 0,
-    });
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    const context = canvas.getContext('2d');
+    if (!context) return;
+
+    context.clearRect(0, 0, CANVAS_WIDTH, CANVAS_HEIGHT);
+
+    // Draw horizontal lines for note pitches
+    context.strokeStyle = '#444444'; // Darker grid lines
+    context.lineWidth = 0.5;
+    for (let i = 0; i <= NUM_PITCHES; i++) {
+      const y = i * NOTE_LANE_HEIGHT;
+      // Draw thicker lines for octaves (every 12 notes, starting from C)
+      if (i % 12 === 0) {
+        context.lineWidth = 1;
+        context.strokeStyle = '#666666';
+      } else {
+        context.lineWidth = 0.5;
+        context.strokeStyle = '#444444';
+      }
+      context.beginPath();
+      context.moveTo(0, y);
+      context.lineTo(CANVAS_WIDTH, y);
+      context.stroke();
+    }
+
+    // Draw vertical lines for beats and measures
+    context.strokeStyle = '#555555';
+    context.lineWidth = 0.5;
+    for (let i = 0; i * BEAT_WIDTH < CANVAS_WIDTH; i++) {
+      const x = i * BEAT_WIDTH;
+      context.beginPath();
+      context.moveTo(x, 0);
+      context.lineTo(x, CANVAS_HEIGHT);
+      context.stroke();
+       // Measure lines (thicker)
+      if (i % 4 === 0) { // Assuming 4 beats per measure
+        context.strokeStyle = '#777777';
+        context.lineWidth = 1;
+        context.beginPath();
+        context.moveTo(x,0);
+        context.lineTo(x, CANVAS_HEIGHT);
+        context.stroke();
+        context.strokeStyle = '#555555'; // Reset for beat lines
+      }
+    }
+  }, []); // Only draw grid once or if dimensions change (not handled here)
+
+  const handleSelectNote = (noteId: string) => {
+    setSelectedNoteId(noteId);
   };
 
+  const handleDeleteNote = (noteId: string) => {
+    deleteNote(noteId);
+    if (selectedNoteId === noteId) {
+      setSelectedNoteId(null);
+    }
+  };
+
+  const handleUpdateLyric = (noteId: string, newLyric: string) => {
+    updateNote(noteId, { lyric: newLyric });
+  };
+
+  const notesArray = Array.from(notes.values());
+
   return (
-    <div style={{ border: '1px solid green', padding: '10px', minHeight: '200px' }}>
-      <h2>Piano Roll Area</h2>
-      <button onClick={handleAddSampleNote}>Add Sample Note</button>
-      {notes.size === 0 && <p>No notes yet.</p>}
-      {Array.from(notes.values()).sort((a,b) => a.tick - b.tick).map((note: Note) => (
-        <div key={note.id} style={{ border: '1px solid lightgray', margin: '5px', padding: '5px' }}>
-          <p>ID: {note.id}</p>
-          <p>Tick: {note.tick}, Pitch: {note.pitch}, Duration: {note.duration}, Lyric: {note.lyric}</p>
-          <p>VEL: {note.vel}, GEN: {note.gen}</p>
-          <button onClick={() => deleteNote(note.id)}>Delete Note</button>
+    <div style={{ border: '1px solid green', padding: '10px', overflow: 'auto', position: 'relative' }}>
+      <h2 style={{ position: 'sticky', top: 0, left: 0, background: 'rgba(255,255,255,0.8)', zIndex: 10 }}>Piano Roll Area</h2>
+      <div style={{ position: 'relative', width: CANVAS_WIDTH, height: CANVAS_HEIGHT }}>
+        <canvas
+          ref={canvasRef}
+          width={CANVAS_WIDTH}
+          height={CANVAS_HEIGHT}
+          style={{ border: '1px solid black', position: 'absolute', top: 0, left: 0 }}
+          onClick={() => setSelectedNoteId(null)} // Click on canvas background deselects notes
+          role="graphics-canvas" // Added for accessibility and testing
+        />
+        <div className="notes-container" style={{ position: 'absolute', top: 0, left: 0, width: CANVAS_WIDTH, height: CANVAS_HEIGHT }}>
+          {notesArray.map((note: NoteType) => {
+            const x = note.tick * PIXELS_PER_TICK;
+            // MIDI pitch 0 is typically at the top or bottom. Let's make higher pitches go upwards (lower y).
+            // So, y = (MAX_PITCH - pitch) * NOTE_LANE_HEIGHT
+            // If pitch 0 is top, y = pitch * NOTE_LANE_HEIGHT
+            // Given canvas origin is top-left, pitch 127 should be at y=0, pitch 0 at y = (127 * NOTE_LANE_HEIGHT)
+            // Or more naturally, pitch 0 at the bottom: y = (NUM_PITCHES - 1 - note.pitch) * NOTE_LANE_HEIGHT
+            const y = (NUM_PITCHES - 1 - note.pitch) * NOTE_LANE_HEIGHT;
+            const noteWidth = note.duration * PIXELS_PER_TICK;
+            const noteHeight = NOTE_LANE_HEIGHT;
+
+            // Basic visibility culling (optional, but good for performance with many notes)
+            // if (x > CANVAS_WIDTH || x + noteWidth < 0 || y > CANVAS_HEIGHT || y + noteHeight < 0) {
+            //   return null;
+            // }
+
+            return (
+              <NoteDisplay
+                key={note.id}
+                note={note}
+                x={x}
+                y={y}
+                width={noteWidth}
+                height={noteHeight}
+                isSelected={note.id === selectedNoteId}
+                onSelect={handleSelectNote}
+                onDelete={handleDeleteNote}
+                onUpdateLyric={handleUpdateLyric}
+                // Pass other necessary props like zIndex if needed for overlapping notes
+              />
+            );
+          })}
         </div>
-      ))}
+      </div>
     </div>
   );
 };

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -21,5 +21,15 @@
     "noFallthroughCasesInSwitch": true
   },
   "include": ["src"],
+  "exclude": [
+    "node_modules",
+    "dist",
+    "**/*.test.tsx",
+    "**/*.test.ts",
+    "src/**/*.test.tsx",
+    "src/**/*.test.ts",
+    "src/**/__tests__/*",
+    "src/**/__mocks__/*"
+  ],
   "references": [{ "path": "./tsconfig.node.json" }]
 }


### PR DESCRIPTION
This commit introduces the initial UI for the piano roll editor, including the PianoKeyboard, PianoRoll (canvas-based), and Note components.

Key features implemented:
- PianoKeyboard: Displays a full 128-key piano keyboard with note names and C4 highlighting.
- PianoRoll: Renders a canvas-based grid for note placement and displays notes.
- Note: Represents individual notes with support for selection, deletion (Del key), and lyric editing (Enter key).
- Integration: PianoKeyboard and PianoRoll are displayed side-by-side.
- Unit Tests: Added tests for the new components using React Testing Library.
- Documentation: Updated README.md to reflect these changes.

The core functionality for displaying and interacting with notes on a piano roll interface is now in place. Further enhancements will include drag-and-drop for note manipulation and more advanced editing features.