### PR TITLE
feat: Add debug button to insert 'DoReMiReDo' notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,9 @@ This command will execute the test suite and report results. (Ensure Vitest or y
 Manual interaction with the UI is still valuable for end-to-end testing:
 
 1.  Run `pnpm tauri dev`.
-2.  Use the "Add Sample Note/Event" buttons in the "Control Area" to populate data if needed (or implement other ways to add notes).
+2.  In the "Control Area", you can use buttons to add sample data:
+    *   "Add Sample Tempo Event" and "Add Sample Time Signature Event" populate respective event types.
+    *   A debug button labeled "Add 'DoReMiReDo' Notes" is available. Clicking this button will add a sequence of five notes (C4-D4-E4-D4-C4, lyrics: "ドレミレド") starting at tick 0, useful for quickly populating the piano roll for testing note display and interaction.
 3.  **Interact with Notes**:
     *   Click on notes in the Piano Roll to select/deselect them.
     *   With a note selected, press 'Delete' or 'Backspace' to remove it.

--- a/src/components/ControlArea.tsx
+++ b/src/components/ControlArea.tsx
@@ -1,10 +1,10 @@
 // src/components/ControlArea.tsx
 import React from 'react';
 import { useMusicData } from '../contexts/MusicDataContext';
-import { TempoEvent, TimeSignatureEvent } from '../types/music';
+import { Note, TempoEvent, TimeSignatureEvent } from '../types/music'; // Added Note type
 
 export const ControlArea: React.FC = () => {
-  const { events, deleteEvent, addEvent } = useMusicData();
+  const { events, deleteEvent, addEvent, addNote } = useMusicData(); // Added addNote
 
   const handleAddSampleTempoEvent = () => {
     addEvent({
@@ -21,11 +21,27 @@ export const ControlArea: React.FC = () => {
     });
   };
 
+  const handleAddDoReMiReDo = () => {
+    const notesToAdd: Omit<Note, 'id'>[] = [
+      { tick: 0, pitch: 60, duration: 480, lyric: "ド", vel: 100, gen: 0 },
+      { tick: 480, pitch: 62, duration: 480, lyric: "レ", vel: 100, gen: 0 },
+      { tick: 960, pitch: 64, duration: 480, lyric: "ミ", vel: 100, gen: 0 },
+      { tick: 1440, pitch: 62, duration: 480, lyric: "レ", vel: 100, gen: 0 },
+      { tick: 1920, pitch: 60, duration: 480, lyric: "ド", vel: 100, gen: 0 },
+    ];
+
+    notesToAdd.forEach(noteData => {
+      addNote(noteData);
+    });
+    console.log("Added 'DoReMiReDo' notes.");
+  };
+
   return (
     <div style={{ border: '1px solid blue', padding: '10px', marginTop: '10px', minHeight: '150px' }}>
       <h2>Control Area</h2>
       <button onClick={handleAddSampleTempoEvent}>Add Sample Tempo Event</button>
       <button onClick={handleAddSampleTimeSignatureEvent}>Add Sample Time Signature Event</button>
+      <button onClick={handleAddDoReMiReDo}>Add 'DoReMiReDo' Notes</button>
       {events.size === 0 && <p>No events yet.</p>}
       {Array.from(events.values()).sort((a,b) => a.tick - b.tick).map((event: TempoEvent | TimeSignatureEvent) => (
         <div key={event.id} style={{ border: '1px solid lightgray', margin: '5px', padding: '5px' }}>


### PR DESCRIPTION
This commit introduces a debug button in the ControlArea to facilitate testing of Note component interactions.

- Added an "Add 'DoReMiReDo' Notes" button to ControlArea.tsx.
- Clicking the button adds a predefined sequence of five notes (C4, D4, E4, D4, C4) with lyrics ("ド", "レ", "ミ", "レ", "ド") to the PianoRoll, starting at tick 0 with 480-tick intervals and durations.
- Updated README.md to mention this new debug feature in the manual testing section.

This feature allows for quick population of the piano roll with sample notes, aiding in the development and testing of note-related functionalities.